### PR TITLE
Add support for separating forecasts by country

### DIFF
--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -18,7 +18,7 @@ class ForecastsController < ApplicationController
     if @forecast.nil? || @forecast.errors.any?
       render "new", locals: { forecast: @forecast }
     else
-      redirect_to forecast_path(@forecast.zipcode)
+      redirect_to country_zipcode_forecast_path(@forecast.country, @forecast.zipcode)
     end
   end
 
@@ -28,7 +28,7 @@ class ForecastsController < ApplicationController
     unless forecast
       # support retrieving new weather forecasts by navigating directly to the url for a specific zipcode
       forecast_retriever = ForecastRetriever.new
-      @forecast = forecast_retriever.retrieve_forecast(address: forecast_zipcode_param)
+      @forecast = forecast_retriever.retrieve_forecast(address: "#{forecast_zipcode_param}, #{forecast_country_param}")
       if @forecast.nil? || @forecast.errors.any?
         render "new", locals: { forecast: @forecast } and return
       end
@@ -46,11 +46,21 @@ class ForecastsController < ApplicationController
   end
 
   def forecast
-    @forecast ||= WeatherForecast.recent.find_by(zipcode: forecast_zipcode_param)
+    @forecast ||= WeatherForecast.recent.find_by(country: forecast_country_param, zipcode: forecast_zipcode_param)
+  end
+
+  def forecast_params
+    params.permit(:country, :zipcode)
+  end
+
+  def forecast_country_param
+    return nil unless forecast_params.key?(:country)
+
+    forecast_params.fetch(:country)
   end
 
   def forecast_zipcode_param
-    params.permit(:id).fetch(:id)
+    forecast_params.fetch(:zipcode)
   end
 
   def weather_forecast_params

--- a/app/controllers/forecasts_controller.rb
+++ b/app/controllers/forecasts_controller.rb
@@ -28,7 +28,7 @@ class ForecastsController < ApplicationController
     unless forecast
       # support retrieving new weather forecasts by navigating directly to the url for a specific zipcode
       forecast_retriever = ForecastRetriever.new
-      @forecast = forecast_retriever.retrieve_forecast(address: "#{forecast_zipcode_param}, #{forecast_country_param}")
+      @forecast = forecast_retriever.retrieve_forecast(address: "#{forecast_zipcode_param}, #{forecast_country}")
       if @forecast.nil? || @forecast.errors.any?
         render "new", locals: { forecast: @forecast } and return
       end
@@ -57,6 +57,10 @@ class ForecastsController < ApplicationController
     return nil unless forecast_params.key?(:country)
 
     forecast_params.fetch(:country)
+  end
+
+  def forecast_country
+    GeolocateService::COUNTRY_MAP[forecast_country_param]
   end
 
   def forecast_zipcode_param

--- a/app/models/forecast_retriever.rb
+++ b/app/models/forecast_retriever.rb
@@ -17,8 +17,9 @@ class ForecastRetriever
       Rails.logger.error("Could not determine a postal code from address #{address}")
       return invalid_address(address)
     end
+    country_param = parsed_address.components["country"][0]&.parameterize
 
-    forecast = WeatherForecast.find_by(zipcode: zipcode)
+    forecast = WeatherForecast.find_by(zipcode: zipcode, country: country_param)
     if forecast.nil? || forecast.expired?
       forecast_data = weather_service.retrieve_weather(latitude: parsed_address.latitude, longitude: parsed_address.longitude)
       upcoming_forecast_data = weather_service.retrieve_weather_forecast(latitude: parsed_address.latitude, longitude: parsed_address.longitude)
@@ -26,7 +27,7 @@ class ForecastRetriever
       if forecast
         forecast.update!(forecast_data: forecast_data, upcoming_forecast_data: upcoming_forecast_data, cached: false)
       else
-        forecast = WeatherForecast.create!(zipcode: zipcode, forecast_data: forecast_data, upcoming_forecast_data: upcoming_forecast_data)
+        forecast = WeatherForecast.create!(country: country_param, zipcode: zipcode, forecast_data: forecast_data, upcoming_forecast_data: upcoming_forecast_data)
       end
     end
 

--- a/app/models/weather_forecast.rb
+++ b/app/models/weather_forecast.rb
@@ -9,8 +9,8 @@ class WeatherForecast < ApplicationRecord
   # but potentially an option for the future.
   scope :expired, -> { where("updated_at < ?", DateTime.now - CACHE_LIFETIME) }
 
-  validates :zipcode, uniqueness: true
-  validates :zipcode, :forecast_data, :upcoming_forecast_data, presence: true
+  validates :zipcode, uniqueness: { scope: :country }
+  validates :country, :zipcode, :forecast_data, :upcoming_forecast_data, presence: true
 
   def expired?
     updated_at < DateTime.now - CACHE_LIFETIME

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,10 @@
 Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
 
-  resources :forecasts, only: [:new, :show, :create]
+  resources :forecasts, only: [:new, :create]
+
+  get "/forecasts/:country/:zipcode", to: "forecasts#show", as: :"country_zipcode_forecast"
+  get "/forecasts/:zipcode", to: "forecasts#show", as: :"zipcode_forecast"
 
   root "forecasts#new"
 end

--- a/db/migrate/20240421054657_add_country_to_weather_forecasts.rb
+++ b/db/migrate/20240421054657_add_country_to_weather_forecasts.rb
@@ -1,0 +1,5 @@
+class AddCountryToWeatherForecasts < ActiveRecord::Migration[7.0]
+  def change
+    add_column :weather_forecasts, :country, :string
+  end
+end

--- a/db/migrate/20240421054657_add_country_to_weather_forecasts.rb
+++ b/db/migrate/20240421054657_add_country_to_weather_forecasts.rb
@@ -1,5 +1,5 @@
 class AddCountryToWeatherForecasts < ActiveRecord::Migration[7.0]
   def change
-    add_column :weather_forecasts, :country, :string
+    add_column :weather_forecasts, :country, :string, null: false, default: "united-states"
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_21_054657) do
     t.json "upcoming_forecast_data", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "country"
+    t.string "country", default: "united-states", null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_18_200739) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_21_054657) do
   create_table "weather_forecasts", force: :cascade do |t|
     t.string "zipcode", null: false
     t.boolean "cached", default: false, null: false
@@ -18,6 +18,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_200739) do
     t.json "upcoming_forecast_data", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "country"
   end
 
 end

--- a/lib/geolocate_service.rb
+++ b/lib/geolocate_service.rb
@@ -1,4 +1,19 @@
 module GeolocateService
+  # list of supported countries - TODO: need a full list that Google Maps supports
+  COUNTRIES = [
+    "United States",
+    "Canada",
+    "Spain",
+    "Germany",
+    "Japan",
+    "Mongolia",
+    "China",
+    "Taiwan",
+    "South Korea",
+    "Argentina",
+  ]
+  COUNTRY_MAP = COUNTRIES.to_h { |country_name| [country_name.parameterize, country_name] }
+
   def geocode_address(address:)
     Google::Maps.geocode(address)[0]
   end

--- a/spec/factories/weather_forecasts.rb
+++ b/spec/factories/weather_forecasts.rb
@@ -3,6 +3,7 @@ require_relative "../forecasts_spec_helper"
 FactoryBot.define do
   factory :weather_forecast do
     zipcode { Faker::Address.zip_code }
+    country { "united-states" }
     forecast_data { ForecastsSpecHelper::WEATHER_JSON }
     upcoming_forecast_data { ForecastsSpecHelper::FORECAST_JSON }
 

--- a/spec/forecasts_spec_helper.rb
+++ b/spec/forecasts_spec_helper.rb
@@ -44,11 +44,12 @@ module ForecastsSpecHelper
 
   def stub_geocode(
     lat:, lon:, zipcode:,
+    country: ["United States"],
     address: Faker::Address.full_address,
     location: instance_double("Google::Maps::Location", latitude: lat, longitude: lon),
     postal_code: [zipcode]
     )
-    allow(location).to receive(:components).and_return({ "postal_code" => postal_code }) if location
+    allow(location).to receive(:components).and_return({ "postal_code" => postal_code, "country" => country }) if location
     expect(Google::Maps).to receive(:geocode).with(address).once.and_return([location])
   end
 

--- a/spec/models/forecast_retriever_spec.rb
+++ b/spec/models/forecast_retriever_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe ForecastRetriever, type: :model do
 
   let(:forecast_retriever) { ForecastRetriever.new }
   let(:zipcode) { Faker::Address.zip_code }
+  let(:country) { "united-states" }
   let(:lat) { 47.56 }
   let(:lon) { -122.28 }
 
@@ -51,7 +52,7 @@ RSpec.describe ForecastRetriever, type: :model do
       expect_any_instance_of(WeatherService).not_to receive(:retrieve_weather)
       expect_any_instance_of(WeatherService).not_to receive(:retrieve_weather_forecast)
 
-      forecast = create(:weather_forecast, zipcode: zipcode)
+      forecast = create(:weather_forecast, zipcode: zipcode, country: country)
       timestamp = forecast.updated_at
       expect do
         forecast_retriever.retrieve_forecast(address: address)

--- a/spec/models/weather_forecast_spec.rb
+++ b/spec/models/weather_forecast_spec.rb
@@ -3,11 +3,12 @@ require 'rails_helper'
 RSpec.describe WeatherForecast, type: :model do
   describe "validations" do
     it "flags any missing fields that are required" do
-      weather_forecast = WeatherForecast.new
+      weather_forecast = WeatherForecast.new(country: nil)
       expect(weather_forecast).not_to be_valid
-      expect(weather_forecast.errors.count).to eq(3)
+      expect(weather_forecast.errors.count).to eq(4)
 
       expect(weather_forecast.errors.messages[:zipcode]).to include("can't be blank")
+      expect(weather_forecast.errors.messages[:country]).to include("can't be blank")
       expect(weather_forecast.errors.messages[:upcoming_forecast_data]).to include("can't be blank")
       expect(weather_forecast.errors.messages[:forecast_data]).to include("can't be blank")
     end
@@ -18,6 +19,13 @@ RSpec.describe WeatherForecast, type: :model do
       weather_forecast_dupe = build(:weather_forecast, zipcode: weather_forecast.zipcode)
       expect(weather_forecast_dupe).not_to be_valid
       expect(weather_forecast_dupe.errors.messages[:zipcode]).to include("has already been taken")
+    end
+
+    it "allows duplicate zipcodes in different countries" do
+      weather_forecast = create(:weather_forecast, country: "japan")
+      expect(weather_forecast).to be_valid
+      weather_forecast_dupe = build(:weather_forecast, zipcode: weather_forecast.zipcode, country: "argentina")
+      expect(weather_forecast_dupe).to be_valid
     end
   end
 

--- a/spec/requests/forecasts_spec.rb
+++ b/spec/requests/forecasts_spec.rb
@@ -7,19 +7,20 @@ RSpec.describe "/forecasts", type: :request do
   let(:lat) { 47.56 }
   let(:lon) { -122.28 }
   let(:zipcode) { "98345" }
+  let(:country) { "United States" }
 
-  describe "GET /show" do
-    it "renders a successful response for a new zipcode" do
-      stub_geocode(lat: lat, lon: lon, zipcode: zipcode, address: zipcode)
+  describe "GET /forecasts/:country/:zipcode" do
+    it "renders a successful response for a new country and zipcode" do
+      stub_geocode(lat: lat, lon: lon, zipcode: zipcode, address: "#{zipcode}, #{country}")
       stub_forecast(lat: lat, lon: lon)
 
-      get forecast_url(zipcode)
+      get country_zipcode_forecast_url(country.parameterize, zipcode)
       expect(response).to be_successful
     end
 
-    it "renders a successful response for a zipcode that we already have a forecast for" do
+    it "renders a successful response for a country/zipcode combo that we already have a forecast for" do
       forecast = create(:weather_forecast)
-      get forecast_url(forecast.zipcode)
+      get country_zipcode_forecast_url(forecast.country, forecast.zipcode)
       expect(response).to be_successful
     end
   end
@@ -51,7 +52,7 @@ RSpec.describe "/forecasts", type: :request do
 
       it "redirects to the new forecast" do
         post forecasts_url, params: { weather_forecast: attributes }
-        expect(response).to redirect_to(forecast_url(WeatherForecast.last.zipcode))
+        expect(response).to redirect_to(country_zipcode_forecast_path(WeatherForecast.last.country, WeatherForecast.last.zipcode))
       end
     end
 

--- a/spec/routing/forecasts_routing_spec.rb
+++ b/spec/routing/forecasts_routing_spec.rb
@@ -6,13 +6,19 @@ RSpec.describe ForecastsController, type: :routing do
       expect(get: "/forecasts/new").to route_to("forecasts#new")
     end
 
-    it "routes to #show" do
-      zipcode = "12345"
-      expect(get: "/forecasts/#{zipcode}").to route_to("forecasts#show", id: zipcode)
-    end
-
     it "routes to #create" do
       expect(post: "/forecasts").to route_to("forecasts#create")
+    end
+
+    it "routes to #zipcode_forecast" do
+      zipcode = "12345"
+      expect(get: "/forecasts/#{zipcode}").to route_to("forecasts#show", zipcode: zipcode)
+    end
+
+    it "routes to #country_zipcode_forecast" do
+      country = "spain"
+      zipcode = "12345"
+      expect(get: "/forecasts/#{country}/#{zipcode}").to route_to("forecasts#show", country: country, zipcode: zipcode)
     end
   end
 end


### PR DESCRIPTION
Addresses the issue of duplicate postal codes - e.g. 08007 is a postal code in Barcelona, Spain and the zipcode for the town of Barrington, NJ, USA. The previous code would automatically default to the first result we got from Google maps, if the input address was just `08007`. Adding a country field to the `weather_forecasts` table in the database here, and incorporating it into the url for getting a forecast. So, for 08007, you can now get separate forecasts at `/forecasts/united-states/08007` and `/forecasts/spain/08007`